### PR TITLE
Draw api update: draw calls take a CameraMatrices struct instead of separate view and proj matrices

### DIFF
--- a/src/examples/collision.zig
+++ b/src/examples/collision.zig
@@ -105,7 +105,7 @@ fn on_draw() void {
     const view = math.Mat4.lookat(.{ .x = 0.0, .y = 0.0, .z = 5.0 }, math.Vec3.zero, math.Vec3.up);
 
     // draw the sprite batch
-    sprite_batch.draw(view, projection, math.Mat4.identity);
+    sprite_batch.draw(.{ .view = view, .proj = projection }, math.Mat4.identity);
 }
 
 fn on_cleanup() !void {

--- a/src/examples/fonts.zig
+++ b/src/examples/fonts.zig
@@ -127,7 +127,7 @@ fn on_draw() void {
     const projection = graphics.getProjectionPerspective(60.0, 0.01, 50.0);
     const view = math.Mat4.lookat(.{ .x = x_wave, .y = y_wave, .z = 6.0 }, math.Vec3.zero, math.Vec3.up);
 
-    font_batch.draw(view, projection, math.Mat4.translate(.{ .x = -3.1, .y = 1.1, .z = 0.0 }));
+    font_batch.draw(.{ .view = view, .proj = projection }, math.Mat4.translate(.{ .x = -3.1, .y = 1.1, .z = 0.0 }));
 }
 
 fn on_cleanup() !void {

--- a/src/examples/forest.zig
+++ b/src/examples/forest.zig
@@ -396,14 +396,14 @@ fn addGrass(pos: math.Vec3, grass_area: u32, grass_size: f32, density: f32) void
 }
 
 fn on_draw() void {
-    camera.update();
+    const view_mats = camera.update();
 
     // draw grass and trees
-    grass_batch.draw(camera.view, camera.projection, math.Mat4.identity);
-    sprite_batch.draw(camera.view, camera.projection, math.Mat4.identity);
+    grass_batch.draw(view_mats, math.Mat4.identity);
+    sprite_batch.draw(view_mats, math.Mat4.identity);
 
     // make clouds follow the camera
-    cloud_batch.draw(camera.view, camera.projection, math.Mat4.translate(camera.position));
+    cloud_batch.draw(view_mats, math.Mat4.translate(camera.position));
 }
 
 fn on_cleanup() !void {

--- a/src/examples/frustums.zig
+++ b/src/examples/frustums.zig
@@ -99,7 +99,7 @@ pub fn on_tick(delta: f32) void {
 }
 
 pub fn on_draw() void {
-    primary_camera.update();
+    const view_mats = primary_camera.update();
     const frustum_model_matrix = delve.math.Mat4.rotate(secondary_camera.yaw_angle, delve.math.Vec3.up);
 
     for (0..10) |x| {
@@ -111,14 +111,14 @@ pub fn on_draw() void {
             const bounds = cube_mesh.bounds.translate(cube_pos);
 
             if (frustum.containsBoundingBox(bounds)) {
-                cube_mesh.drawWithMaterial(&material_highlight, primary_camera.view, primary_camera.projection, cube_model_matrix);
+                cube_mesh.drawWithMaterial(&material_highlight, view_mats, cube_model_matrix);
             } else {
-                cube_mesh.draw(primary_camera.view, primary_camera.projection, cube_model_matrix);
+                cube_mesh.draw(view_mats, cube_model_matrix);
             }
         }
     }
 
-    frustum_mesh.draw(primary_camera.view, primary_camera.projection, frustum_model_matrix);
+    frustum_mesh.draw(view_mats, frustum_model_matrix);
 }
 
 pub fn createFrustumMesh() !delve.graphics.mesh.Mesh {

--- a/src/examples/lighting.zig
+++ b/src/examples/lighting.zig
@@ -137,7 +137,7 @@ fn on_tick(delta: f32) void {
 }
 
 fn on_draw() void {
-    camera.update();
+    const view_mats = camera.update();
 
     var model = Mat4.translate(Vec3.new(0.0, -0.75, 0.0));
     model = model.mul(Mat4.rotate(-90, Vec3.new(1.0, 0.0, 0.0)));
@@ -167,9 +167,9 @@ fn on_draw() void {
     cube1.material.params = animated_mesh.mesh.material.params;
     cube2.material.params = animated_mesh.mesh.material.params;
 
-    animated_mesh.draw(camera.view, camera.projection, model);
-    cube1.draw(camera.view, camera.projection, Mat4.identity);
-    cube2.draw(camera.view, camera.projection, Mat4.translate(Vec3.new(-2, 0, 0)).mul(Mat4.rotate(time * 0.1, Vec3.y_axis)));
+    animated_mesh.draw(view_mats, model);
+    cube1.draw(view_mats, Mat4.identity);
+    cube2.draw(view_mats, Mat4.translate(Vec3.new(-2, 0, 0)).mul(Mat4.rotate(time * 0.1, Vec3.y_axis)));
 }
 
 fn on_cleanup() !void {

--- a/src/examples/meshbuilder.zig
+++ b/src/examples/meshbuilder.zig
@@ -95,7 +95,7 @@ pub fn on_tick(delta: f32) void {
 }
 
 pub fn on_draw() void {
-    camera.update();
+    const view_mats = camera.update();
     var model = math.Mat4.identity;
 
     const frustum = camera.getViewFrustum();
@@ -103,7 +103,7 @@ pub fn on_draw() void {
         return;
     }
 
-    cube1.draw(camera.view, camera.projection, model.mul(math.Mat4.rotate(@floatCast(time * 40.0), math.Vec3.new(0, 1, 0))));
-    cube2.draw(camera.view, camera.projection, model);
-    cube3.draw(camera.view, camera.projection, model);
+    cube1.draw(view_mats, model.mul(math.Mat4.rotate(@floatCast(time * 40.0), math.Vec3.new(0, 1, 0))));
+    cube2.draw(view_mats, model);
+    cube3.draw(view_mats, model);
 }

--- a/src/examples/meshes.zig
+++ b/src/examples/meshes.zig
@@ -117,17 +117,17 @@ fn on_draw() void {
     if (mesh_test == null)
         return;
 
-    camera.update();
+    const view_mats = camera.update();
 
     var model = Mat4.translate(Vec3.new(2.0, 0.0, 0.0));
     model = model.mul(Mat4.rotate(time * 0.6, Vec3.new(0.0, 1.0, 0.0)));
 
     const sin_val = std.math.sin(time * 0.006) + 0.5;
     mesh_test.?.material.params.draw_color = Color.new(sin_val, sin_val, sin_val, 1.0);
-    mesh_test.?.draw(camera.view, camera.projection, model);
+    mesh_test.?.draw(view_mats, model);
 
     model = Mat4.translate(Vec3.new(-2.0, 0.0, 0.0));
-    mesh_test.?.draw(camera.view, camera.projection, model);
+    mesh_test.?.draw(view_mats, model);
 }
 
 fn on_cleanup() !void {

--- a/src/examples/passes.zig
+++ b/src/examples/passes.zig
@@ -151,13 +151,13 @@ pub fn pre_draw() void {
     graphics.beginPass(offscreen_pass, sky_color);
 
     // draw using the offscreen camera
-    camera_offscreen.update();
+    const offscreen_view_mats = camera_offscreen.update();
 
     // draw a few cubes inside the offscreen pass
     const translate = math.Mat4.translate(math.Vec3.new(-3, 0, 0));
     const rotate = math.Mat4.rotate(@floatCast(time * 160.0), math.Vec3.y_axis);
-    cube1.draw(camera_offscreen.view, camera_offscreen.projection, translate.mul(rotate));
-    cube2.draw(camera_offscreen.view, camera_offscreen.projection, math.Mat4.identity);
+    cube1.draw(offscreen_view_mats, translate.mul(rotate));
+    cube2.draw(offscreen_view_mats, math.Mat4.identity);
 
     // render pass for the primary nested module
     nested_example_1.runFullRenderLifecycle();
@@ -168,10 +168,10 @@ pub fn pre_draw() void {
 
 pub fn on_draw() void {
     // use the fps camera
-    camera.update();
+    const view_mats = camera.update();
 
     // draw the screen cube
-    cube3.draw(camera.view, camera.projection, math.Mat4.translate(math.Vec3.new(0, 0, -20)).mul(math.Mat4.rotate(@floatCast(time * 10.0), math.Vec3.new(0, 1, 0))));
+    cube3.draw(view_mats, math.Mat4.translate(math.Vec3.new(0, 0, -20)).mul(math.Mat4.rotate(@floatCast(time * 10.0), math.Vec3.new(0, 1, 0))));
 
     // reset the clear color back to ours
     graphics.setClearColor(delve.colors.examples_bg_dark);

--- a/src/examples/quakemap.zig
+++ b/src/examples/quakemap.zig
@@ -215,17 +215,17 @@ pub fn on_tick(delta: f32) void {
 }
 
 pub fn on_draw() void {
-    camera.update();
+    const view_mats = camera.update();
     const model = math.Mat4.identity;
 
     for (0..map_meshes.items.len) |idx| {
-        map_meshes.items[idx].draw(camera.view, camera.projection, model);
+        map_meshes.items[idx].draw(view_mats, model);
     }
     for (0..entity_meshes.items.len) |idx| {
-        entity_meshes.items[idx].draw(camera.view, camera.projection, model);
+        entity_meshes.items[idx].draw(view_mats, model);
     }
 
-    cube_mesh.draw(camera.view, camera.projection, math.Mat4.translate(camera.position));
+    cube_mesh.draw(view_mats, math.Mat4.translate(camera.position));
 }
 
 pub fn do_player_move(delta: f32) void {

--- a/src/examples/rays.zig
+++ b/src/examples/rays.zig
@@ -108,7 +108,7 @@ pub fn on_tick(delta: f32) void {
 }
 
 pub fn on_draw() void {
-    camera.update();
+    const view_mats = camera.update();
 
     const ray_start = delve.math.Vec3.new(0, 0, 0);
     var ray_dir = delve.math.Vec3.new(1.0, 0.0, 0.0);
@@ -129,15 +129,15 @@ pub fn on_draw() void {
             const rayhit = ray.intersectOrientedBoundingBox(bounds);
 
             if (rayhit != null) {
-                cube_mesh.drawWithMaterial(&material_highlight, camera.view, camera.projection, cube_model_matrix);
+                cube_mesh.drawWithMaterial(&material_highlight, view_mats, cube_model_matrix);
 
                 const hit_model_matrix = delve.math.Mat4.translate(rayhit.?.hit_pos);
-                hit_mesh.drawWithMaterial(&material_hitpoint, camera.view, camera.projection, hit_model_matrix);
+                hit_mesh.drawWithMaterial(&material_hitpoint, view_mats, hit_model_matrix);
             } else {
-                cube_mesh.draw(camera.view, camera.projection, cube_model_matrix);
+                cube_mesh.draw(view_mats, cube_model_matrix);
             }
         }
     }
 
-    ray_mesh.draw(camera.view, camera.projection, delve.math.Mat4.rotate(time * 10.0, delve.math.Vec3.up));
+    ray_mesh.draw(view_mats, delve.math.Mat4.rotate(time * 10.0, delve.math.Vec3.up));
 }

--- a/src/examples/skinned-meshes.zig
+++ b/src/examples/skinned-meshes.zig
@@ -150,7 +150,7 @@ fn on_tick(delta: f32) void {
 }
 
 fn on_draw() void {
-    camera.update();
+    const view_mats = camera.update();
 
     var model = Mat4.translate(Vec3.new(0.0, -0.75, 0.0));
     model = model.mul(Mat4.rotate(-90, Vec3.new(1.0, 0.0, 0.0)));
@@ -168,7 +168,7 @@ fn on_draw() void {
         mesh_test.setBoneTransform(neck_bone_name, nt.*);
     }
 
-    mesh_test.draw(camera.view, camera.projection, model);
+    mesh_test.draw(view_mats, model);
 }
 
 fn on_cleanup() !void {

--- a/src/examples/sprite-animation.zig
+++ b/src/examples/sprite-animation.zig
@@ -110,7 +110,7 @@ fn on_draw() void {
     const view = delve.math.Mat4.lookat(.{ .x = 0.0, .y = 0.0, .z = 3.0 }, delve.math.Vec3.zero, delve.math.Vec3.up);
 
     // draw the sprite batch
-    sprite_batch.draw(view, projection, delve.math.Mat4.identity);
+    sprite_batch.draw(.{ .view = view, .proj = projection }, delve.math.Mat4.identity);
 }
 
 fn on_cleanup() !void {

--- a/src/examples/sprites.zig
+++ b/src/examples/sprites.zig
@@ -202,7 +202,7 @@ fn on_draw() void {
     view = view.mul(math.Mat4.translate(view_translate));
     view = view.mul(math.Mat4.rotate(25.0, .{ .x = 0.0, .y = 1.0, .z = 0.0 }));
 
-    test_batch.draw(view, projection, math.Mat4.identity);
+    test_batch.draw(.{ .view = view, .proj = projection }, math.Mat4.identity);
 }
 
 fn on_cleanup() !void {

--- a/src/framework/api/draw.zig
+++ b/src/framework/api/draw.zig
@@ -38,7 +38,7 @@ pub fn libDraw() void {
     const model = math.Mat4.translate(.{ .x = 0.0, .y = 0.0, .z = -2.5 });
 
     shape_batch.apply();
-    shape_batch.draw(view, proj, model);
+    shape_batch.draw(.{ .view = view, .proj = proj }, model);
 }
 
 /// Called when things are shutting down

--- a/src/framework/api/graphics.zig
+++ b/src/framework/api/graphics.zig
@@ -40,7 +40,7 @@ pub fn libDraw() void {
     const model = math.Mat4.translate(.{ .x = 0.0, .y = 0.0, .z = -2.5 });
 
     sprite_batch.apply();
-    sprite_batch.draw(view, proj, model);
+    sprite_batch.draw(.{ .view = view, .proj = proj }, model);
 }
 
 /// Called when things are shutting down

--- a/src/framework/graphics/batcher.zig
+++ b/src/framework/graphics/batcher.zig
@@ -19,6 +19,7 @@ const Mat4 = math.Mat4;
 const Color = colors.Color;
 const TextureRegion = sprites.TextureRegion;
 const Rect = spatial_rect.Rect;
+const CameraMatrices = graphics.CameraMatrices;
 
 const max_indices = 64000;
 const max_vertices = max_indices;
@@ -171,10 +172,10 @@ pub const SpriteBatcher = struct {
     }
 
     /// Draws all the batches
-    pub fn draw(self: *SpriteBatcher, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
+    pub fn draw(self: *SpriteBatcher, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
         var it = self.batches.iterator();
         while (it.next()) |batcher| {
-            batcher.value_ptr.draw(view_matrix, proj_matrix, model_matrix);
+            batcher.value_ptr.draw(cam_matrices, model_matrix);
         }
     }
 
@@ -450,22 +451,22 @@ pub const Batcher = struct {
     }
 
     /// Submit a draw call to draw all shapes for this batch
-    pub fn draw(self: *Batcher, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
+    pub fn draw(self: *Batcher, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
         if (self.material == null) {
-            self.drawWithoutMaterial(view_matrix, proj_matrix, model_matrix);
+            self.drawWithoutMaterial(cam_matrices, model_matrix);
         } else {
-            self.drawWithMaterial(view_matrix, proj_matrix, model_matrix);
+            self.drawWithMaterial(cam_matrices, model_matrix);
         }
     }
 
     /// Submit a draw call to draw all shapes for this batch
-    pub fn drawWithoutMaterial(self: *Batcher, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
+    pub fn drawWithoutMaterial(self: *Batcher, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
         if (self.index_pos == 0)
             return;
 
         // Make our default uniform blocks
         const vs_params = VSParams{
-            .projViewMatrix = proj_matrix.mul(view_matrix),
+            .projViewMatrix = cam_matrices.proj.mul(cam_matrices.view),
             .modelMatrix = model_matrix,
             .in_color = .{ 1.0, 1.0, 1.0, 1.0 },
         };
@@ -482,14 +483,14 @@ pub const Batcher = struct {
     }
 
     /// Submit a draw call to draw all shapes for this batch
-    pub fn drawWithMaterial(self: *Batcher, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
+    pub fn drawWithMaterial(self: *Batcher, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
         if (self.index_pos == 0)
             return;
 
         if (self.material == null)
             return;
 
-        graphics.drawWithMaterial(&self.bindings, self.material.?, view_matrix, proj_matrix, model_matrix);
+        graphics.drawWithMaterial(&self.bindings, self.material.?, cam_matrices, model_matrix);
     }
 
     /// Expand the buffers for this batch if needed to fit the new size

--- a/src/framework/graphics/camera.zig
+++ b/src/framework/graphics/camera.zig
@@ -187,24 +187,32 @@ pub const Camera = struct {
         self.pitch(mouse_delta.y * mouse_mod * turn_speed);
     }
 
-    pub fn update(self: *Camera) void {
+    /// Sets our view matrices from the current camera state, returns the current matrices
+    pub fn update(self: *Camera) graphics.CameraMatrices {
         self.projection = Mat4.persp(self.fov, self.aspect, self.near, self.far);
 
         // third person camera
         if (self.view_mode == .THIRD_PERSON) {
             self.view = Mat4.lookat(self.position.add(self.direction.scale(self.boom_arm_length)), self.position, self.up);
-            return;
+            return self.getViewMatrices();
         }
 
         // first person camera
         self.view = Mat4.lookat(Vec3.zero, Vec3.zero.sub(self.direction), self.up);
         self.view = self.view.mul(Mat4.rotate(self.roll_angle, self.direction));
         self.view = self.view.mul(Mat4.translate(self.position.scale(-1)));
+
+        return self.getViewMatrices();
+    }
+
+    /// Returns the current view matrices
+    pub fn getViewMatrices(self: *Camera) graphics.CameraMatrices {
+        return .{ .view = self.view, .proj = self.projection };
     }
 
     /// Applies projection and view, returns a projection * view matrix
     pub fn getProjView(self: *Camera) Mat4 {
-        self.update();
+        _ = self.update();
         return self.projection.mul(self.view);
     }
 

--- a/src/framework/graphics/mesh.zig
+++ b/src/framework/graphics/mesh.zig
@@ -9,6 +9,7 @@ const boundingbox = @import("../spatial/boundingbox.zig");
 
 const PackedVertex = graphics.PackedVertex;
 const Vertex = graphics.Vertex;
+const CameraMatrices = graphics.CameraMatrices;
 const Color = colors.Color;
 const Rect = @import("../spatial/rect.zig").Rect;
 const Frustum = @import("../spatial/frustum.zig").Frustum;
@@ -156,13 +157,13 @@ pub const Mesh = struct {
     }
 
     /// Draw this mesh
-    pub fn draw(self: *Mesh, view_matrix: math.Mat4, proj_matrix: math.Mat4, model_matrix: math.Mat4) void {
-        graphics.drawWithMaterial(&self.bindings, &self.material, view_matrix, proj_matrix, model_matrix);
+    pub fn draw(self: *Mesh, cam_matrices: CameraMatrices, model_matrix: math.Mat4) void {
+        graphics.drawWithMaterial(&self.bindings, &self.material, cam_matrices, model_matrix);
     }
 
     /// Draw this mesh, using the specified material instead of the set one
-    pub fn drawWithMaterial(self: *Mesh, material: *graphics.Material, view_matrix: math.Mat4, proj_matrix: math.Mat4, model_matrix: math.Mat4) void {
-        graphics.drawWithMaterial(&self.bindings, material, view_matrix, proj_matrix, model_matrix);
+    pub fn drawWithMaterial(self: *Mesh, material: *graphics.Material, cam_matrices: CameraMatrices, model_matrix: math.Mat4) void {
+        graphics.drawWithMaterial(&self.bindings, material, cam_matrices, model_matrix);
     }
 };
 

--- a/src/framework/graphics/skinned-mesh.zig
+++ b/src/framework/graphics/skinned-mesh.zig
@@ -10,6 +10,7 @@ const mesh = @import("mesh.zig");
 const interpolation = @import("../utils/interpolation.zig");
 
 const Vertex = graphics.Vertex;
+const CameraMatrices = graphics.CameraMatrices;
 const Color = colors.Color;
 const Rect = @import("../spatial/rect.zig").Rect;
 const Frustum = @import("../spatial/frustum.zig").Frustum;
@@ -216,21 +217,21 @@ pub const SkinnedMesh = struct {
     }
 
     /// Draw this mesh
-    pub fn draw(self: *SkinnedMesh, view_matrix: math.Mat4, proj_matrix: math.Mat4, model_matrix: math.Mat4) void {
+    pub fn draw(self: *SkinnedMesh, cam_matrices: CameraMatrices, model_matrix: math.Mat4) void {
         if (self.joint_locations_dirty)
             self.applySkeletonTransforms();
 
         self.mesh.material.params.joints = &self.joint_locations;
-        graphics.drawWithMaterial(&self.mesh.bindings, &self.mesh.material, view_matrix, proj_matrix, model_matrix);
+        graphics.drawWithMaterial(&self.mesh.bindings, &self.mesh.material, cam_matrices, model_matrix);
     }
 
     /// Draw this mesh, using the specified material instead of the set one
-    pub fn drawWithMaterial(self: *SkinnedMesh, material: *graphics.Material, view_matrix: math.Mat4, proj_matrix: math.Mat4, model_matrix: math.Mat4) void {
+    pub fn drawWithMaterial(self: *SkinnedMesh, material: *graphics.Material, cam_matrices: CameraMatrices, model_matrix: math.Mat4) void {
         if (self.joint_locations_dirty)
             self.applySkeletonTransforms();
 
         self.mesh.material.params.joints = &self.joint_locations;
-        graphics.drawWithMaterial(&self.mesh.bindings, material, view_matrix, proj_matrix, model_matrix);
+        graphics.drawWithMaterial(&self.mesh.bindings, material, cam_matrices, model_matrix);
     }
 
     /// Resets all joints back to their identity matrix

--- a/src/framework/platform/graphics.zig
+++ b/src/framework/platform/graphics.zig
@@ -125,6 +125,12 @@ pub const Anything = struct {
     size: usize = 0,
 };
 
+// The camera view matrices that will be passed to draw calls
+pub const CameraMatrices = struct {
+    view: Mat4,
+    proj: Mat4,
+};
+
 /// A packed mesh vertex
 pub const PackedVertex = struct {
     x: f32,
@@ -887,11 +893,14 @@ pub const Material = struct {
     }
 
     /// Applys shader uniform variables for this Material
-    pub fn applyUniforms(self: *Material, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
+    pub fn applyUniforms(self: *Material, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
         // If no default layout is set, we'll treat the first uniform block like any other
         // otherwise, we start custom blocks at index 1.
         const has_default_vs: bool = self.default_vs_uniform_layout.len > 0;
         const has_default_fs: bool = self.default_fs_uniform_layout.len > 0;
+
+        const view_matrix = cam_matrices.view;
+        const proj_matrix = cam_matrices.proj;
 
         // Set our default uniform vars first
         if (has_default_vs and self.use_default_params) {
@@ -1144,15 +1153,15 @@ pub fn draw(bindings: *Bindings, shader: *Shader) void {
 }
 
 /// Draw a part of a binding, using a material
-pub fn drawSubsetWithMaterial(bindings: *Bindings, start: u32, end: u32, material: *Material, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
+pub fn drawSubsetWithMaterial(bindings: *Bindings, start: u32, end: u32, material: *Material, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
     bindings.updateFromMaterial(material);
-    material.applyUniforms(view_matrix, proj_matrix, model_matrix);
+    material.applyUniforms(cam_matrices, model_matrix);
     drawSubset(bindings, start, end, &material.shader);
 }
 
 /// Draw a whole binding, using a material
-pub fn drawWithMaterial(bindings: *Bindings, material: *Material, view_matrix: Mat4, proj_matrix: Mat4, model_matrix: Mat4) void {
-    drawSubsetWithMaterial(bindings, 0, @intCast(bindings.length), material, view_matrix, proj_matrix, model_matrix);
+pub fn drawWithMaterial(bindings: *Bindings, material: *Material, cam_matrices: CameraMatrices, model_matrix: Mat4) void {
+    drawSubsetWithMaterial(bindings, 0, @intCast(bindings.length), material, cam_matrices, model_matrix);
 }
 
 /// Returns a small 2x2 solid color texture


### PR DESCRIPTION
Changing the draw calls to use a CameraMatrices struct allows us to do stuff like cache inverse view matrices once instead of needing to compute them a lot.

* `camera.update()` now returns a new CameraMatrices struct
* `platform.graphics` draw calls now take a CameraMatrices struct instead of proj and view Mat4s