### PR TITLE
Cleaning up debug draw resources from graphics on deinit

### DIFF
--- a/src/framework/debug.zig
+++ b/src/framework/debug.zig
@@ -222,7 +222,7 @@ fn addLogEntry(comptime fmt: []const u8, args: anytype, level: LogLevel) void {
 
     // Use an array list to write our string
     var string_writer = std.ArrayList(u8).init(allocator);
-    errdefer string_writer.deinit();
+    defer string_writer.deinit();
 
     string_writer.writer().print(fmt, args) catch {
         std.debug.print("Could not write to debug log! - Out of memory?\n", .{});

--- a/src/framework/platform/graphics.zig
+++ b/src/framework/platform/graphics.zig
@@ -1054,6 +1054,12 @@ pub fn init() !void {
 /// Stops the graphics subystem
 pub fn deinit() void {
     debug.log("Graphics subsystem stopping", .{});
+
+    // clean up our debug draw resources
+    state.debug_shader.destroy();
+    tex_white.destroy();
+    tex_black.destroy();
+    tex_grey.destroy();
 }
 
 /// Called at the start of a frame


### PR DESCRIPTION
Related to https://github.com/Interrupt/delve-framework/issues/42