### PR TITLE
Fix for OSX not detecting memory leaks when using a General Purpose Allocator

### DIFF
--- a/src/examples/clear.zig
+++ b/src/examples/clear.zig
@@ -2,15 +2,11 @@ const delve = @import("delve");
 const app = delve.app;
 const std = @import("std");
 
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-
 // This example does nothing but open a blank window!
 
 var time: f32 = 0.0;
 
 pub fn main() !void {
-    defer _ = gpa.deinit();
-
     const clear_module = delve.modules.Module{
         .name = "clear_example",
         .init_fn = on_init,
@@ -24,7 +20,8 @@ pub fn main() !void {
         // See https://github.com/ziglang/zig/issues/19072
         try delve.init(std.heap.c_allocator);
     } else {
-        try delve.init(gpa.allocator());
+        // Using the default allocator will let us detect memory leaks
+        try delve.init(delve.mem.createDefaultAllocator());
     }
 
     try delve.modules.registerModule(clear_module);

--- a/src/framework/debug.zig
+++ b/src/framework/debug.zig
@@ -233,12 +233,8 @@ fn addLogEntry(comptime fmt: []const u8, args: anytype, level: LogLevel) void {
         return;
     };
 
-    const written = string_writer.toOwnedSlice() catch {
-        std.debug.print("Error: string_writer.toOwnedSlice() - Out of memory?\n", .{});
-        return;
-    };
-
     // Log to std out
+    const written = string_writer.items;
     std.debug.print("{s}\n", .{written});
 
     // Keep the line in the console log

--- a/src/framework/mem.zig
+++ b/src/framework/mem.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+// Hack: keep our GeneralPurposeAllocator internal to the delve framework, as quitting on OSX
+// seems to quit immediately after Sokol cleans up.
+pub var default_gpa = std.heap.GeneralPurposeAllocator(.{ .stack_trace_frames = 32 }){};
+
 pub var main_allocator: std.mem.Allocator = undefined;
 
 var did_init: bool = false;
@@ -9,6 +13,11 @@ pub fn init(allocator: std.mem.Allocator) void {
     did_init = true;
 }
 
+pub fn deinit() void {
+    // Can check for memory leaks if we use the default GPA
+    _ = default_gpa.deinit();
+}
+
 pub fn getAllocator() std.mem.Allocator {
     if (!did_init) {
         // We can at least warn people that things were not initialized properly
@@ -16,4 +25,8 @@ pub fn getAllocator() std.mem.Allocator {
     }
 
     return main_allocator;
+}
+
+pub fn createDefaultAllocator() std.mem.Allocator {
+    return default_gpa.allocator();
 }

--- a/src/framework/mem.zig
+++ b/src/framework/mem.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 // Hack: keep our GeneralPurposeAllocator internal to the delve framework, as quitting on OSX
 // seems to quit immediately after Sokol cleans up.
-pub var default_gpa = std.heap.GeneralPurposeAllocator(.{ .stack_trace_frames = 32 }){};
+pub var default_gpa = std.heap.GeneralPurposeAllocator(.{ .stack_trace_frames = 16 }){};
 
 pub var main_allocator: std.mem.Allocator = undefined;
 

--- a/src/framework/platform/app.zig
+++ b/src/framework/platform/app.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const app = @import("../app.zig");
 const debug = @import("../debug.zig");
 const gfx = @import("graphics.zig");
+const mem = @import("../mem.zig");
 const modules = @import("../modules.zig");
 const time = @import("std").time;
 const sokol_app_backend = @import("backends/sokol/app.zig");
@@ -130,6 +131,7 @@ fn on_cleanup() void {
     app.stopSubsystems();
     gfx.deinit();
     debug.deinit();
+    mem.deinit();
 }
 
 fn on_frame() void {


### PR DESCRIPTION
Sokol seems to quit the app immediately after running the Sokol cleanup lifecycle even on OSX so it's easy to miss running a deinit on a GeneralPurposeAllocator if that's how the app was setup. This change adds a General Purpose Allocator inside of the Delve Framework's memory subsystem for us to use directly, and deinit is always called on that at the end of shutdown.