### PR TITLE
Simplifying the Shader API to not need to pass around pointers to shaders

### DIFF
--- a/src/examples/fonts.zig
+++ b/src/examples/fonts.zig
@@ -106,7 +106,7 @@ fn on_pre_draw() void {
     // Ideally you would only do this when the text updates, and just draw the batch until then
     font_batch.reset();
 
-    font_batch.useShader(&shader_blend);
+    font_batch.useShader(shader_blend);
 
     if (found_font) |font| {
         // give the header a bit of padding

--- a/src/examples/forest.zig
+++ b/src/examples/forest.zig
@@ -280,7 +280,7 @@ fn pre_draw() void {
 
 /// Add the ground plane to the sprite batch
 fn addGround(ground_size: math.Vec2) void {
-    sprite_batch.useShader(&shader_blend);
+    sprite_batch.useShader(shader_blend);
     sprite_batch.useTexture(graphics.tex_white);
 
     // ground plane needs to be big enough to cover where the trees will be
@@ -303,7 +303,7 @@ fn addClouds(density: f32) void {
     const billboard_dir = math.Vec3.new(camera.direction.x, camera.direction.y, camera.direction.z).norm();
     const rot_matrix = math.Mat4.billboard(billboard_dir, camera.up);
 
-    cloud_batch.useShader(&shader_blend);
+    cloud_batch.useShader(shader_blend);
     cloud_batch.useTexture(tex_treesheet);
     cloud_batch.reset();
 

--- a/src/examples/sprites.zig
+++ b/src/examples/sprites.zig
@@ -138,9 +138,9 @@ fn pre_draw() void {
         }
 
         if (@mod(i, 5) == 0) {
-            test_batch.useShader(&shader_blend);
+            test_batch.useShader(shader_blend);
         } else {
-            test_batch.useShader(&shader_opaque);
+            test_batch.useShader(shader_opaque);
         }
 
         var transform: math.Mat4 = undefined;
@@ -160,7 +160,7 @@ fn pre_draw() void {
         }
     }
 
-    test_batch.useShader(&shader_blend);
+    test_batch.useShader(shader_blend);
 
     // test a line!
     const line_y_start = std.math.sin(time * 0.01);

--- a/src/framework/graphics/batcher.zig
+++ b/src/framework/graphics/batcher.zig
@@ -32,7 +32,7 @@ const BatcherConfig = struct {
     min_vertices: usize = 128,
     min_indices: usize = 128,
     texture: ?graphics.Texture = null,
-    shader: ?*graphics.Shader = null,
+    shader: ?graphics.Shader = null,
     material: ?*graphics.Material = null,
     flip_tex_y: bool = false,
 };
@@ -46,7 +46,7 @@ pub const SpriteBatcher = struct {
     config: BatcherConfig = BatcherConfig{},
     current_batch_key: u64 = 0,
     current_tex: graphics.Texture = undefined,
-    current_shader: *graphics.Shader = undefined,
+    current_shader: graphics.Shader = undefined,
     current_material: ?*graphics.Material = null,
 
     // If we needed to make resources, we need to clean them up later too
@@ -79,7 +79,7 @@ pub const SpriteBatcher = struct {
     }
 
     /// Switch the current batch to one for the given shader
-    pub fn useShader(self: *SpriteBatcher, shader: *graphics.Shader) void {
+    pub fn useShader(self: *SpriteBatcher, shader: graphics.Shader) void {
         self.current_batch_key = makeSpriteBatchKey(self.current_tex, shader);
         self.current_shader = shader;
         self.current_material = null;
@@ -221,7 +221,7 @@ pub const SpriteBatcher = struct {
     }
 };
 
-fn makeSpriteBatchKey(tex: graphics.Texture, shader: *const graphics.Shader) u64 {
+fn makeSpriteBatchKey(tex: graphics.Texture, shader: graphics.Shader) u64 {
     return tex.handle + (shader.handle * 1000000);
 }
 
@@ -240,7 +240,7 @@ pub const Batcher = struct {
     vertex_pos: usize,
     index_pos: usize,
     bindings: graphics.Bindings,
-    shader: *graphics.Shader,
+    shader: graphics.Shader,
     material: ?*graphics.Material = null,
     transform: Mat4 = Mat4.identity,
     flip_tex_y: bool = false,
@@ -492,7 +492,7 @@ pub const Batcher = struct {
         self.shader.applyUniformBlock(.FS, 0, graphics.asAnything(&fs_params));
         self.shader.applyUniformBlock(.VS, 0, graphics.asAnything(&vs_params));
 
-        graphics.draw(&self.bindings, self.shader);
+        graphics.draw(&self.bindings, &self.shader);
     }
 
     /// Submit a draw call to draw all shapes for this batch

--- a/src/framework/platform/graphics.zig
+++ b/src/framework/platform/graphics.zig
@@ -1259,8 +1259,8 @@ pub fn createDebugTexture() Texture {
 }
 
 /// Return our default shader
-pub fn getDefaultShader() *Shader {
-    return &state.default_shader;
+pub fn getDefaultShader() Shader {
+    return state.default_shader;
 }
 
 fn convertFilterModeToSamplerDesc(filter: FilterMode) sg.SamplerDesc {


### PR DESCRIPTION
This makes it so that Shaders hold a pointer to their own pipeline ArrayList, so that Shaders can be passed around by value and not by pointer everywhere.