### PR TITLE
During texture creation, images are now passed as values and not pointers

### DIFF
--- a/src/examples/debugdraw.zig
+++ b/src/examples/debugdraw.zig
@@ -56,7 +56,7 @@ fn on_init() !void {
         debug.log("Could not load test texture", .{});
         return;
     };
-    texture = graphics.Texture.init(&test_image);
+    texture = graphics.Texture.init(test_image);
 
     graphics.setClearColor(colors.examples_bg_dark);
 }

--- a/src/examples/easing.zig
+++ b/src/examples/easing.zig
@@ -64,7 +64,7 @@ fn on_init() !void {
         debug.log("Could not load test texture", .{});
         return;
     };
-    texture = graphics.Texture.init(&test_image);
+    texture = graphics.Texture.init(test_image);
 }
 
 fn on_tick(delta: f32) void {

--- a/src/examples/forest.zig
+++ b/src/examples/forest.zig
@@ -189,7 +189,7 @@ fn on_init() !void {
         return;
     };
 
-    tex_treesheet = graphics.Texture.init(&treesheet_img);
+    tex_treesheet = graphics.Texture.init(treesheet_img);
 
     // make our default shader
     shader_blend = graphics.Shader.initDefault(.{ .blend_mode = .NONE, .cull_mode = .NONE });

--- a/src/examples/framepacing.zig
+++ b/src/examples/framepacing.zig
@@ -74,7 +74,7 @@ fn on_init() !void {
         debug.log("Could not load test texture", .{});
         return;
     };
-    texture = graphics.Texture.init(&test_image);
+    texture = graphics.Texture.init(test_image);
 }
 
 fn on_tick(delta: f32) void {

--- a/src/examples/lighting.zig
+++ b/src/examples/lighting.zig
@@ -90,7 +90,7 @@ fn on_init() !void {
 
     var base_img: images.Image = try images.loadFile(mesh_texture_file);
     defer base_img.deinit();
-    const tex_base = graphics.Texture.init(&base_img);
+    const tex_base = graphics.Texture.init(base_img);
 
     // Create a material out of our shader and textures
     skinned_mesh_material = try delve.platform.graphics.Material.init(.{

--- a/src/examples/meshbuilder.zig
+++ b/src/examples/meshbuilder.zig
@@ -49,7 +49,7 @@ pub fn on_init() !void {
         return;
     };
     defer img.deinit();
-    const tex = graphics.Texture.init(&img);
+    const tex = graphics.Texture.init(img);
 
     const shader = graphics.Shader.initFromBuiltin(.{ .vertex_attributes = delve.graphics.mesh.getShaderAttributes() }, delve.shaders.default_mesh);
 

--- a/src/examples/meshes.zig
+++ b/src/examples/meshes.zig
@@ -78,7 +78,7 @@ fn on_init() !void {
         return;
     };
     defer base_img.deinit();
-    const tex_base = graphics.Texture.init(&base_img);
+    const tex_base = graphics.Texture.init(base_img);
 
     // Load the emissive texture for the mesh
     const emissive_texture_file = "assets/meshes/SciFiHelmet_Emissive_512.png";
@@ -87,7 +87,7 @@ fn on_init() !void {
         return;
     };
     defer emissive_img.deinit();
-    const tex_emissive = graphics.Texture.init(&emissive_img);
+    const tex_emissive = graphics.Texture.init(emissive_img);
 
     // Make our emissive shader from one that is pre-compiled
     const loaded_shader = graphics.Shader.initFromBuiltin(.{ .vertex_attributes = mesh.getShaderAttributes() }, emissive_shader_builtin);

--- a/src/examples/passes.zig
+++ b/src/examples/passes.zig
@@ -63,7 +63,7 @@ pub fn on_init() !void {
         return;
     };
     defer img.deinit();
-    const tex = graphics.Texture.init(&img);
+    const tex = graphics.Texture.init(img);
 
     // Create our offscreen passes
     offscreen_pass = graphics.RenderPass.init(.{ .width = 1024, .height = 768 });

--- a/src/examples/quakemap.zig
+++ b/src/examples/quakemap.zig
@@ -192,7 +192,7 @@ pub fn on_init() !void {
                     continue;
                 };
                 defer tex_img.deinit();
-                const tex = graphics.Texture.init(&tex_img);
+                const tex = graphics.Texture.init(tex_img);
 
                 const mat = try graphics.Material.init(.{
                     .shader = shader,

--- a/src/examples/skinned-meshes.zig
+++ b/src/examples/skinned-meshes.zig
@@ -90,7 +90,7 @@ fn on_init() !void {
         return;
     };
     defer base_img.deinit();
-    const tex_base = graphics.Texture.init(&base_img);
+    const tex_base = graphics.Texture.init(base_img);
 
     // Create a material out of our shader and textures
     material = try delve.platform.graphics.Material.init(.{

--- a/src/examples/sprite-animation.zig
+++ b/src/examples/sprite-animation.zig
@@ -61,7 +61,7 @@ fn on_init() !void {
     defer spritesheet_image.deinit();
 
     // make the texture to draw
-    sprite_texture = graphics.Texture.init(&spritesheet_image);
+    sprite_texture = graphics.Texture.init(spritesheet_image);
 
     // Load the default shader, but from a Yaml description file!
     const loaded_shader = try delve.graphics.shaders.loadFromYaml(.{}, "assets/shaders/built/default/default_reflection.yaml");

--- a/src/examples/sprites.zig
+++ b/src/examples/sprites.zig
@@ -87,8 +87,8 @@ fn on_init() !void {
     defer test_image_2.deinit();
 
     // make some textures from our images
-    texture_1 = graphics.Texture.init(&test_image_1);
-    texture_2 = graphics.Texture.init(&test_image_2);
+    texture_1 = graphics.Texture.init(test_image_1);
+    texture_2 = graphics.Texture.init(test_image_2);
 
     // make some shaders for testing
     shader_opaque = graphics.Shader.initDefault(.{});

--- a/src/framework/api/assets.zig
+++ b/src/framework/api/assets.zig
@@ -39,7 +39,7 @@ pub fn get_texture(filename: [*:0]const u8) i64 {
     const filename_len = filename_idx;
 
     debug.log("Assets: Loading Image: {s}...", .{filename});
-    var new_img: images.Image = images.loadFile(filename[0..filename_len :0]) catch {
+    const new_img: images.Image = images.loadFile(filename[0..filename_len :0]) catch {
         debug.log("Assets: Error loading image asset: {s}", .{filename});
         return -1;
     };
@@ -55,7 +55,7 @@ pub fn get_texture(filename: [*:0]const u8) i64 {
         return -1;
     };
 
-    const texture = graphics.Texture.init(&new_img);
+    const texture = graphics.Texture.init(new_img);
     texture_handles.put(new_handle, texture) catch {
         debug.log("Assets: Error caching loaded texture!", .{});
         return -1;

--- a/src/framework/platform/graphics.zig
+++ b/src/framework/platform/graphics.zig
@@ -439,7 +439,7 @@ pub const Texture = struct {
     sokol_image: ?sg.Image,
 
     /// Creates a new texture from an Image
-    pub fn init(image: *images.Image) Texture {
+    pub fn init(image: images.Image) Texture {
         defer next_texture_handle += 1;
 
         var img_desc: sg.ImageDesc = .{


### PR DESCRIPTION
This makes texture creation look much cleaner, and the image bytes are a pointer anyway so not much data is really being copied.