### PR TITLE
Using the full float versions of colors for vertices now

### DIFF
--- a/src/framework/graphics/batcher.zig
+++ b/src/framework/graphics/batcher.zig
@@ -302,13 +302,13 @@ pub const Batcher = struct {
         const v = region.v;
         const u_2 = region.u_2;
         const v_2 = region.v_2;
-        const color_i = color.toInt();
+        const color_a = color.toArray();
 
         const verts = &[_]Vertex{
-            .{ .x = v0.x, .y = v0.y, .z = 0, .color = color_i, .u = u, .v = v_2 },
-            .{ .x = v1.x, .y = v1.y, .z = 0, .color = color_i, .u = u_2, .v = v_2 },
-            .{ .x = v2.x, .y = v2.y, .z = 0, .color = color_i, .u = u_2, .v = v },
-            .{ .x = v3.x, .y = v3.y, .z = 0, .color = color_i, .u = u, .v = v },
+            .{ .x = v0.x, .y = v0.y, .z = 0, .color = color_a, .u = u, .v = v_2 },
+            .{ .x = v1.x, .y = v1.y, .z = 0, .color = color_a, .u = u_2, .v = v_2 },
+            .{ .x = v2.x, .y = v2.y, .z = 0, .color = color_a, .u = u_2, .v = v },
+            .{ .x = v3.x, .y = v3.y, .z = 0, .color = color_a, .u = u, .v = v },
         };
 
         const indices = &[_]u32{ 0, 1, 2, 0, 2, 3 };
@@ -389,12 +389,12 @@ pub const Batcher = struct {
             return;
         };
 
-        const color_i = color.toInt();
+        const color_a = color.toArray();
 
         const verts = &[_]Vertex{
-            .{ .x = v0.x, .y = v0.y, .z = 0, .color = color_i, .u = uv0.x, .v = uv0.y },
-            .{ .x = v1.x, .y = v1.y, .z = 0, .color = color_i, .u = uv1.x, .v = uv1.y },
-            .{ .x = v2.x, .y = v2.y, .z = 0, .color = color_i, .u = uv2.x, .v = uv2.y },
+            .{ .x = v0.x, .y = v0.y, .z = 0, .color = color_a, .u = uv0.x, .v = uv0.y },
+            .{ .x = v1.x, .y = v1.y, .z = 0, .color = color_a, .u = uv1.x, .v = uv1.y },
+            .{ .x = v2.x, .y = v2.y, .z = 0, .color = color_a, .u = uv2.x, .v = uv2.y },
         };
 
         const indices = &[_]u32{ 0, 1, 2 };

--- a/src/framework/graphics/mesh.zig
+++ b/src/framework/graphics/mesh.zig
@@ -98,7 +98,7 @@ pub const Mesh = struct {
         };
         defer allocator.free(vertices);
 
-        const white_color = colors.white.toInt();
+        const white_color = colors.white.toArray();
 
         for (mesh_positions.items, 0..) |vert, i| {
             vertices[i].x = vert[0];
@@ -257,7 +257,7 @@ pub fn getSkinnedVertexLayout() graphics.VertexLayout {
 pub fn getShaderAttributes() []const graphics.ShaderAttribute {
     return &[_]graphics.ShaderAttribute{
         .{ .name = "pos", .attr_type = .FLOAT3, .binding = .VERT_PACKED },
-        .{ .name = "color0", .attr_type = .UBYTE4N, .binding = .VERT_PACKED },
+        .{ .name = "color0", .attr_type = .FLOAT4, .binding = .VERT_PACKED },
         .{ .name = "texcoord0", .attr_type = .FLOAT2, .binding = .VERT_PACKED },
         .{ .name = "normals", .attr_type = .FLOAT3, .binding = .VERT_NORMALS },
         .{ .name = "tangents", .attr_type = .FLOAT4, .binding = .VERT_TANGENTS },
@@ -267,7 +267,7 @@ pub fn getShaderAttributes() []const graphics.ShaderAttribute {
 pub fn getSkinnedShaderAttributes() []const graphics.ShaderAttribute {
     return &[_]graphics.ShaderAttribute{
         .{ .name = "pos", .attr_type = .FLOAT3, .binding = .VERT_PACKED },
-        .{ .name = "color0", .attr_type = .UBYTE4N, .binding = .VERT_PACKED },
+        .{ .name = "color0", .attr_type = .FLOAT4, .binding = .VERT_PACKED },
         .{ .name = "texcoord0", .attr_type = .FLOAT2, .binding = .VERT_PACKED },
         .{ .name = "normals", .attr_type = .FLOAT3, .binding = .VERT_NORMALS },
         .{ .name = "tangents", .attr_type = .FLOAT4, .binding = .VERT_TANGENTS },
@@ -298,13 +298,13 @@ pub const MeshBuilder = struct {
         const v = 0.0;
         const u_2 = 1.0;
         const v_2 = 1.0;
-        const color_i = color.toInt();
+        const color_array = color.toArray();
 
         const verts = &[_]PackedVertex{
-            .{ .x = v0.x, .y = v0.y, .z = 0, .color = color_i, .u = u, .v = v_2 },
-            .{ .x = v1.x, .y = v1.y, .z = 0, .color = color_i, .u = u_2, .v = v_2 },
-            .{ .x = v2.x, .y = v2.y, .z = 0, .color = color_i, .u = u_2, .v = v },
-            .{ .x = v3.x, .y = v3.y, .z = 0, .color = color_i, .u = u, .v = v },
+            .{ .x = v0.x, .y = v0.y, .z = 0, .color = color_array, .u = u, .v = v_2 },
+            .{ .x = v1.x, .y = v1.y, .z = 0, .color = color_array, .u = u_2, .v = v_2 },
+            .{ .x = v2.x, .y = v2.y, .z = 0, .color = color_array, .u = u_2, .v = v },
+            .{ .x = v3.x, .y = v3.y, .z = 0, .color = color_array, .u = u, .v = v },
         };
 
         const indices = &[_]u32{ 0, 1, 2, 0, 2, 3 };
@@ -340,12 +340,12 @@ pub const MeshBuilder = struct {
         const v = 0.0;
         const u_2 = 1.0;
         const v_2 = 1.0;
-        const color_i = color.toInt();
+        const color_a = color.toArray();
 
         const verts = &[_]PackedVertex{
-            .{ .x = v0.x, .y = v0.y, .z = v0.z, .color = color_i, .u = u, .v = v_2 },
-            .{ .x = v1.x, .y = v1.y, .z = v1.z, .color = color_i, .u = u_2, .v = v_2 },
-            .{ .x = v2.x, .y = v2.y, .z = v2.z, .color = color_i, .u = u_2, .v = v },
+            .{ .x = v0.x, .y = v0.y, .z = v0.z, .color = color_a, .u = u, .v = v_2 },
+            .{ .x = v1.x, .y = v1.y, .z = v1.z, .color = color_a, .u = u_2, .v = v_2 },
+            .{ .x = v2.x, .y = v2.y, .z = v2.z, .color = color_a, .u = u_2, .v = v },
         };
 
         const normal = v0.cross(v1).mulMat4(transform).norm().toArray();

--- a/src/framework/platform/graphics.zig
+++ b/src/framework/platform/graphics.zig
@@ -151,7 +151,7 @@ pub const PackedVertex = struct {
     x: f32,
     y: f32,
     z: f32,
-    color: u32 = 0xFFFFFFFF,
+    color: [4]f32 = [_]f32{ 1.0, 1.0, 1.0, 1.0 },
     u: f32 = 0,
     v: f32 = 0,
 
@@ -187,7 +187,7 @@ pub const Vertex = struct {
 
     // returns the packed version of this vertex
     pub fn pack(self: *const Vertex) PackedVertex {
-        return .{ .x = self.pos.x, .y = self.pos.y, .z = self.pos.z, .u = self.uv.x, .v = self.uv.y, .color = self.color.toInt() };
+        return .{ .x = self.pos.x, .y = self.pos.y, .z = self.pos.z, .u = self.uv.x, .v = self.uv.y, .color = self.color.toArray() };
     }
 };
 
@@ -317,7 +317,7 @@ pub const ShaderConfig = struct {
     cull_mode: CullMode = .NONE,
     vertex_attributes: []const ShaderAttribute = &[_]ShaderAttribute{
         .{ .name = "pos", .attr_type = .FLOAT3, .binding = .VERT_PACKED },
-        .{ .name = "color0", .attr_type = .UBYTE4N, .binding = .VERT_PACKED },
+        .{ .name = "color0", .attr_type = .FLOAT4, .binding = .VERT_PACKED },
         .{ .name = "texcoord0", .attr_type = .FLOAT2, .binding = .VERT_PACKED },
     },
     is_depth_pixel_format: bool = false,
@@ -1073,11 +1073,12 @@ pub fn init() !void {
     debugtext.setup(text_desc);
 
     // Create vertex buffer with debug quad vertices
+    const white_color_array = colors.white.toArray();
     const debug_vertices = &[_]PackedVertex{
-        .{ .x = 0.0, .y = 1.0, .z = 0.0, .color = 0xFFFFFFFF, .u = 0, .v = 0 },
-        .{ .x = 1.0, .y = 1.0, .z = 0.0, .color = 0xFFFFFFFF, .u = 1, .v = 0 },
-        .{ .x = 1.0, .y = 0.0, .z = 0.0, .color = 0xFFFFFFFF, .u = 1, .v = 1 },
-        .{ .x = 0.0, .y = 0.0, .z = 0.0, .color = 0xFFFFFFFF, .u = 0, .v = 1 },
+        .{ .x = 0.0, .y = 1.0, .z = 0.0, .color = white_color_array, .u = 0, .v = 0 },
+        .{ .x = 1.0, .y = 1.0, .z = 0.0, .color = white_color_array, .u = 1, .v = 0 },
+        .{ .x = 1.0, .y = 0.0, .z = 0.0, .color = white_color_array, .u = 1, .v = 1 },
+        .{ .x = 0.0, .y = 0.0, .z = 0.0, .color = white_color_array, .u = 0, .v = 1 },
     };
     const debug_indices = &[_]u32{ 0, 1, 2, 0, 2, 3 };
 


### PR DESCRIPTION
Using the packed form of colors for vertices is not ideal for a lot of circumstances. Using the full float representations allows for higher color fidelity past the 0-255 range.