### PR TITLE
More utils/QuakeMap improvements

### DIFF
--- a/src/framework/utils/quakemap.zig
+++ b/src/framework/utils/quakemap.zig
@@ -692,7 +692,7 @@ pub const QuakeMap = struct {
 
     /// Builds meshes for the map, bucketed by materials
     pub fn buildWorldMeshes(self: *const QuakeMap, allocator: Allocator, transform: Mat4, materials: *std.StringHashMap(QuakeMaterial), fallback_material: ?*QuakeMaterial) !std.ArrayList(Mesh) {
-        return try self.buildMeshesForEntity(&self.worldspawn, allocator, transform, materials, fallback_material);
+        return try buildMeshesForEntity(&self.worldspawn, allocator, transform, materials, fallback_material);
     }
 
     /// Builds meshes for all entity solids - in a real scenario, you'll probably want to use buildMeshesForEntity instead
@@ -726,9 +726,7 @@ pub const QuakeMap = struct {
     }
 
     /// Builds meshes for a specific entity
-    pub fn buildMeshesForEntity(self: *const QuakeMap, entity: *const Entity, allocator: Allocator, transform: Mat4, materials: *std.StringHashMap(QuakeMaterial), fallback_material: ?*QuakeMaterial) !std.ArrayList(Mesh) {
-        _ = self;
-
+    pub fn buildMeshesForEntity(entity: *const Entity, allocator: Allocator, transform: Mat4, materials: *std.StringHashMap(QuakeMaterial), fallback_material: ?*QuakeMaterial) !std.ArrayList(Mesh) {
         // Make our mesh buckets - we'll make a new mesh per material!
         var mesh_builders = std.StringHashMap(mesh.MeshBuilder).init(allocator);
         defer mesh_builders.deinit();

--- a/src/framework/utils/quakemap.zig
+++ b/src/framework/utils/quakemap.zig
@@ -692,7 +692,7 @@ pub const QuakeMap = struct {
 
     /// Builds meshes for the map, bucketed by materials
     pub fn buildWorldMeshes(self: *const QuakeMap, allocator: Allocator, transform: Mat4, materials: *std.StringHashMap(QuakeMaterial), fallback_material: ?*QuakeMaterial) !std.ArrayList(Mesh) {
-        return try buildMeshesForEntity(&self.worldspawn, allocator, transform, materials, fallback_material);
+        return try self.buildMeshesForEntity(&self.worldspawn, allocator, transform, materials, fallback_material);
     }
 
     /// Builds meshes for all entity solids - in a real scenario, you'll probably want to use buildMeshesForEntity instead
@@ -726,7 +726,9 @@ pub const QuakeMap = struct {
     }
 
     /// Builds meshes for a specific entity
-    pub fn buildMeshesForEntity(entity: *const Entity, allocator: Allocator, transform: Mat4, materials: *std.StringHashMap(QuakeMaterial), fallback_material: ?*QuakeMaterial) !std.ArrayList(Mesh) {
+    pub fn buildMeshesForEntity(self: *const QuakeMap, entity: *const Entity, allocator: Allocator, transform: Mat4, materials: *std.StringHashMap(QuakeMaterial), fallback_material: ?*QuakeMaterial) !std.ArrayList(Mesh) {
+        _ = self;
+
         // Make our mesh buckets - we'll make a new mesh per material!
         var mesh_builders = std.StringHashMap(mesh.MeshBuilder).init(allocator);
         defer mesh_builders.deinit();


### PR DESCRIPTION
- QuakeMapHit can now get the hit face with `getFace()`
- QuakeMaterial now has a `hidden` property that can cause it to skip being added to the final mesh