### PR TITLE
Fix zig version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Delve Framework
 
-Delve is a simple framework for building games written in Zig using Lua for scripting. Currently targeting `Zig 0.14.x`
+Delve is a simple framework for building games written in Zig using Lua for scripting. Currently targeting `Zig 0.15.x`
 
 *This is in early development and the api is still coming together, so be warned!*
 


### PR DESCRIPTION
To reflect: https://github.com/Interrupt/delve-framework/releases/tag/0.1.3

All examples tested and (appear) correct on zig 15.2

No longer compiles with zig 14.1 or zig 14.0