### PR TITLE
Add a link to the 'delve-framework-example' repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,36 +68,21 @@ Some example modules are included automatically to exercise some code paths, the
 * [Mesh Drawing Example](src/examples/meshes.zig)
 * [Debug Drawing Example](src/examples/debugdraw.zig)
 
-## Building the examples
+## Getting started
 
-- Add dependency repository link
+### Add delve-framework as a dependency
 
-`build.zig.zon`
-```
-.{
-    .name = "my_project",
-    .version = "0.0.1",
-    .dependencies = .{
-        .delve = .{
-            .url = "git+https://github.com/Interrupt/delve-framework/tree/0.12.x.git#___COMMIT_HASH___",
-            // add compilers suggested line about .hash
-        },
-    },
-}
-```
-- Link dependency module
-`build.zig`
-```
-    const delve = b.dependency("delve", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    exe.root_module.addImport("delve", delve.module("delve"));
-```
+This repository demonstrates how to include and use the Delve Framework in another Zig project using Zig's package manager.
 
-- Just build
-```java
-zig build run
+https://github.com/Interrupt/delve-framework-example
+
+
+
+## Examples
+
+List examples (and other build-steps)
+```
+zig build --list-steps
 ```
 
 ### Build and run examples


### PR DESCRIPTION
Don't merge until the example  is up-to-date: i.e. merge  https://github.com/Interrupt/delve-framework-example/pull/3

Add a link to the delve-framework-example repository, as it neatly demonstrates how to add it as a dependency. And unlike instructions, you can easily verify that it is correct by running:
```
zig build run

zig build run -Dtarget=wasm32-emscripten
```

----

I removed the existing section called "Building the examples". Apart from the confusing name, it appears to be very out of date, and has nothing for building  the -wasm target.

----

Add a section about `zig build --list-steps`

This will show all the examples, including _run-quakemdl_ and _run-frustum_, which are not on the list of examples.