### PR TITLE
Lua binding: helpers to call Lua functions from Zig

### DIFF
--- a/src/examples/lua.zig
+++ b/src/examples/lua.zig
@@ -9,6 +9,15 @@ const fps_module = delve.module.fps_counter;
 
 // This example shows how to use lua scripting
 
+// Setup a registry of our bound types to let us use them in Lua
+const registry = delve.scripting.binder.Registry(.{
+    .entries = &[_]delve.scripting.binder.BoundType{
+        .{ .Type = TestBindingStruct, .name = "TestStruct", .ignore_fields = &[_][:0]const u8{"ignoreMe"}, .mixin = Mixin },
+        .{ .Type = Cat, .name = "Cat" },
+    },
+    .ignored_types = &[_]type{std.mem.Allocator},
+});
+
 pub const TestBindingStruct = struct {
     message: []const u8,
     allocator: std.mem.Allocator = undefined, // should be ignored!
@@ -42,6 +51,17 @@ pub const TestBindingStruct = struct {
         delve.debug.fatal("Should not be callable!", .{});
     }
 
+    // Use a LuaRef to pass along a Lua variable on the stack back to Lua
+    pub fn testLuaPassthrough(self: *TestBindingStruct, test_passthrough: delve.scripting.binder.LuaRef) void {
+        _ = self;
+
+        const lua = delve.scripting.lua.getLua();
+        const str: []const u8 = "hello from zig!";
+        registry.callGlobalFunction(lua, "TestGlobalFunc", .{ str, test_passthrough }) catch {
+            delve.debug.fatal("Could not call TestGlobalFunc in Lua!", .{});
+        };
+    }
+
     // Lua garbage collection will automatically call destroy if found
     pub fn destroy(self: *TestBindingStruct) void {
         _ = self;
@@ -72,6 +92,7 @@ pub const Cat = struct {
 
 const testBindingScript =
     \\ -- Test out binding Zig structs and using them in Lua
+    \\ TestGlobalFunc = function(arg1, arg2) print("TetsGlobalFunc:", arg1, arg2[1]) end
     \\ local TestStruct = require("TestStruct")
     \\ print(TestStruct.constant_message)
     \\ local test_binding = TestStruct.new("Hello from Lua!")
@@ -96,6 +117,7 @@ const testBindingScript =
     \\ test_pointer:ignoreMeToo()
     \\ print(test_pointer.allocator)
     \\ test_pointer.allocator = "blah"
+    \\ test_pointer:testLuaPassthrough({ "hello from lua!" })
 ;
 
 pub fn main() !void {
@@ -132,13 +154,6 @@ pub fn lua_test_on_init() !void {
     const lua = delve.scripting.lua.getLua();
 
     // You can register structs with Lua so we can interact with them on the Lua side!
-    const registry = delve.scripting.binder.Registry(.{
-        .entries = &[_]delve.scripting.binder.BoundType{
-            .{ .Type = TestBindingStruct, .name = "TestStruct", .ignore_fields = &[_][:0]const u8{"ignoreMe"}, .mixin = Mixin },
-            .{ .Type = Cat, .name = "Cat" },
-        },
-        .ignored_types = &[_]type{std.mem.Allocator},
-    });
     try registry.bindTypes(lua);
 
     // Load and run a simple Lua command

--- a/src/framework/scripting/binder.zig
+++ b/src/framework/scripting/binder.zig
@@ -20,6 +20,12 @@ pub const RegistryConfig = struct {
     ignored_types: ?[]const type = null,
 };
 
+// Use LuaRef when binding to pass along a Lua reference without converting it
+// Good for passing through from Lua -> Zig -> Lua in one stack
+pub const LuaRef = struct {
+    lua_idx: i32,
+};
+
 pub fn Registry(comptime cfg: RegistryConfig) type {
     return struct {
         pub const registry = cfg.entries;
@@ -409,6 +415,13 @@ pub fn Registry(comptime cfg: RegistryConfig) type {
                         const param_type = param.type.?;
                         const lua_idx = i + 1;
 
+                        if (param_type == LuaRef) {
+                            args[i] = LuaRef{
+                                .lua_idx = lua_idx,
+                            };
+                            continue;
+                        }
+
                         args[i] = toAny(luaState, param_type, lua_idx) catch {
                             debug.warning("Lua: '{s}:{s}': Could not bind arg {any} to {any}", .{ mod_name, name, lua_idx, param_type });
                             luaState.raiseErrorStr("Could not bind argument! Should be type %s", .{@typeName(param_type)});
@@ -445,6 +458,12 @@ pub fn Registry(comptime cfg: RegistryConfig) type {
             const val_type = @TypeOf(value);
 
             // Push the value onto the stack
+
+            // If it's a LuaRef, just pass forward this index
+            if (val_type == LuaRef) {
+                luaState.pushValue(value.lua_idx);
+                return 1;
+            }
 
             switch (@typeInfo(val_type)) {
                 .void => {
@@ -600,6 +619,54 @@ pub fn Registry(comptime cfg: RegistryConfig) type {
                     return try luaState.toAny(T, lua_idx);
                 },
             }
+        }
+
+        pub fn callGlobalFunction(luaState: *Lua, func_name: [:0]const u8, args: anytype) !void {
+            const top = luaState.getTop();
+            defer luaState.setTop(top);
+
+            _ = try luaState.getGlobal(func_name);
+
+            if (!luaState.isFunction(-1)) {
+                debug.log("Lua callGlobalFunction: global func '{s}' not found!", .{func_name});
+                return;
+            }
+
+            try callFunctionAuto(luaState, args);
+        }
+
+        pub fn callFunctionAuto(luaState: *Lua, args: anytype) !void {
+            const top = luaState.getTop();
+            defer luaState.setTop(top);
+
+            if (!luaState.isFunction(-1)) {
+                debug.log("Lua callFunctionAuto: top of stack is not a function!", .{});
+                return;
+            }
+
+            // Keep track of how much we are pushing onto the Lua stack
+            var count: i32 = 0;
+
+            // Pass all args
+            // Should be an struct tuple, push each field
+            const T = @TypeOf(args);
+            switch (@typeInfo(T)) {
+                .@"struct" => |info| {
+                    if (!info.is_tuple) {
+                        @compileError("callLuaFunction: Expected struct tuple!");
+                    }
+
+                    inline for (info.fields) |field| {
+                        const field_val = @field(args, field.name);
+                        count = count + pushAny(luaState, field_val);
+                    }
+                },
+                else => {
+                    @compileError("callLuaFunction: Expected struct tuple!");
+                },
+            }
+
+            try luaState.protectedCall(.{ .args = count });
         }
 
         pub fn makeLuaOpenLibFn(lib_funcs: []const zlua.FnReg) fn (*Lua) i32 {


### PR DESCRIPTION
Adding helpers to call Lua functions using our bound types.

Also adding a LuaRef type which just holds a Lua stack index. There are times where Zig might be used to route data from Lua back to Lua, this lets us pass along any lua variable without needing to unbox it first to pass it back.